### PR TITLE
oauth_callback is mandatory. changing the README to reflect that fact

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -20,15 +20,19 @@ As a matter of fact it has been pulled out from an OAuth Rails Plugin http://cod
 
 == Demonstration of usage
 
+We need to specify the oauth_callback url explicitly, otherwise it defaults to "oob" (Out of Band)
+
+  @callback_url = "http://127.0.0.1:3000/oauth/callback"
+
 Create a new consumer instance by passing it a configuration hash:
 
   @consumer = OAuth::Consumer.new("key","secret", :site => "https://agree2")
 
 Start the process by requesting a token
 
-  @request_token = @consumer.get_request_token
+  @request_token = @consumer.get_request_token(:oauth_callback => @callback_url)
   session[:request_token] = @request_token
-  redirect_to @request_token.authorize_url
+  redirect_to @request_token.authorize_url(:oauth_callback => @callback_url)
 
 When user returns create an access_token
 


### PR DESCRIPTION
I used the example in the README as is for twitter oauth, and I kept getting the out of band pin login instead. I didn't know I was supposed to specify oauth_callback for both get_request_token and get_authorize_url.

This behaviour differs from version 0.3.4, so maybe it might be a good idea to document it.
