### PR TITLE
when do  post request with Typhoeus,  the hash params is not request.body, but request.params

### DIFF
--- a/lib/oauth/request_proxy/typhoeus_request.rb
+++ b/lib/oauth/request_proxy/typhoeus_request.rb
@@ -43,8 +43,8 @@ module OAuth::RequestProxy::Typhoeus
 
     def post_parameters
       # Post params are only used if posting form data
-      if(method == 'POST' && request.headers['Content-Type'] && request.headers['Content-Type'].downcase == 'application/x-www-form-urlencoded')
-        request.body || {}
+      if(method == 'POST')
+        OAuth::Helper.stringify_keys(request.params || {})
       else
         {}
       end

--- a/test/test_typhoeus_request_proxy.rb
+++ b/test/test_typhoeus_request_proxy.rb
@@ -10,64 +10,64 @@ class TyphoeusRequestProxyTest < Test::Unit::TestCase
   def test_that_proxy_simple_get_request_works
     request = ::Typhoeus::Request.new('/test?key=value')
     request_proxy = OAuth::RequestProxy.proxy(request, {:uri => 'http://example.com/test?key=value'})
-
+  
     expected_parameters = {'key' => ['value']}
     assert_equal expected_parameters, request_proxy.parameters_for_signature
     assert_equal 'http://example.com/test', request_proxy.normalized_uri
     assert_equal 'GET', request_proxy.method
   end
-
+  
   def test_that_proxy_simple_post_request_works_with_arguments
     request = Typhoeus::Request.new('/test', :method => :post)
     params = {'key' => 'value'}
     request_proxy = OAuth::RequestProxy.proxy(request, {:uri => 'http://example.com/test', :parameters => params})
-
+  
     expected_parameters = {'key' => 'value'}
     assert_equal expected_parameters, request_proxy.parameters_for_signature
     assert_equal 'http://example.com/test', request_proxy.normalized_uri
     assert_equal 'POST', request_proxy.method
   end
-
+  
   def test_that_proxy_simple_post_request_works_with_form_data
     request = Typhoeus::Request.new('/test', :method => :post,
-      :body => {'key' => 'value'},
+      :params => {'key' => 'value'},
       :headers => {'Content-Type' => 'application/x-www-form-urlencoded'})
     request_proxy = OAuth::RequestProxy.proxy(request, {:uri => 'http://example.com/test'})
-
+  
     expected_parameters = {'key' => 'value'}
     assert_equal expected_parameters, request_proxy.parameters_for_signature
     assert_equal 'http://example.com/test', request_proxy.normalized_uri
     assert_equal 'POST', request_proxy.method
   end
-
+  
   def test_that_proxy_simple_put_request_works_with_arguments
     request = Typhoeus::Request.new('/test', :method => :put)
     params = {'key' => 'value'}
     request_proxy = OAuth::RequestProxy.proxy(request, {:uri => 'http://example.com/test', :parameters => params})
-
+  
     expected_parameters = {'key' => 'value'}
     assert_equal expected_parameters, request_proxy.parameters_for_signature
     assert_equal 'http://example.com/test', request_proxy.normalized_uri
     assert_equal 'PUT', request_proxy.method
   end
-
+  
   def test_that_proxy_simple_put_request_works_with_form_data
-    request = Typhoeus::Request.new('/test', :method => :put, :body => {'key' => 'value'})
+    request = Typhoeus::Request.new('/test', :method => :put, :params => {'key' => 'value'})
     request_proxy = OAuth::RequestProxy.proxy(request, {:uri => 'http://example.com/test'})
-
-    expected_parameters = {}
+  
+    expected_parameters = {'key' => ['value']}
     assert_equal expected_parameters, request_proxy.parameters_for_signature
     assert_equal 'http://example.com/test', request_proxy.normalized_uri
     assert_equal 'PUT', request_proxy.method
   end
-
+  
   def test_that_proxy_post_request_works_with_mixed_parameter_sources
     request = Typhoeus::Request.new('/test?key=value',
       :method => :post,
-      :body => {'key2' => 'value2'},
+      :params => {'key2' => 'value2'},
       :headers => {'Content-Type' => 'application/x-www-form-urlencoded'})
     request_proxy = OAuth::RequestProxy.proxy(request, {:uri => 'http://example.com/test?key=value', :parameters => {'key3' => 'value3'}})
-
+  
     expected_parameters = {'key' => ['value'], 'key2' => 'value2', 'key3' => 'value3'}
     assert_equal expected_parameters, request_proxy.parameters_for_signature
     assert_equal 'http://example.com/test', request_proxy.normalized_uri


### PR DESCRIPTION
I'm currently using typhoeus 0.2.4. when doing post request,
req = Typhoeus::Request.new(uri,:method => :post,
   :params => {:status => 'bye',:pic=>File.open('/Users/xx/Desktop/lion2orig.jpg')})

the parameters are req.params, not req.body.
if put post params is body,eg
req = Typhoeus::Request.new(uri,:method => :post,
   :body => {:status => 'bye',:pic=>File.open('/Users/xx/Desktop/lion2orig.jpg')})
when executing , it will fails..
