### PR TITLE
Open Net::HTTPGenericRequest class instead of Net::HTTPRequest

### DIFF
--- a/lib/oauth/client/net_http.rb
+++ b/lib/oauth/client/net_http.rb
@@ -83,7 +83,7 @@ private
   end
 
   def oauth_body_hash_required?
-    request_body_permitted? && content_type != "application/x-www-form-urlencoded"
+    request_body_permitted? && !content_type.to_s.downcase.start_with?("application/x-www-form-urlencoded")
   end
 
   def set_oauth_header

--- a/lib/oauth/request_proxy/action_controller_request.rb
+++ b/lib/oauth/request_proxy/action_controller_request.rb
@@ -36,7 +36,7 @@ module OAuth::RequestProxy
         params << header_params.to_query
         params << request.query_string unless query_string_blank?
 
-        if request.post? && request.content_type == Mime::Type.lookup("application/x-www-form-urlencoded")
+        if request.post? && request.content_type.to_s.downcase.start_with?("application/x-www-form-urlencoded")
           params << request.raw_post
         end
       end

--- a/lib/oauth/request_proxy/curb_request.rb
+++ b/lib/oauth/request_proxy/curb_request.rb
@@ -42,7 +42,7 @@ module OAuth::RequestProxy::Curl
       post_body = {}
 
       # Post params are only used if posting form data
-      if (request.headers['Content-Type'] && request.headers['Content-Type'].downcase == 'application/x-www-form-urlencoded')
+      if (request.headers['Content-Type'] && request.headers['Content-Type'].to_s.downcase.start_with?("application/x-www-form-urlencoded"))
 
         request.post_body.split("&").each do |str|
           param = str.split("=")

--- a/lib/oauth/request_proxy/em_http_request.rb
+++ b/lib/oauth/request_proxy/em_http_request.rb
@@ -41,7 +41,7 @@ module OAuth::RequestProxy::EventMachine
 
     def post_parameters
       headers = request.options[:head] || {}
-      form_encoded = headers['Content-Type'].to_s.downcase == 'application/x-www-form-urlencoded'
+      form_encoded = headers['Content-Type'].to_s.downcase.start_with?("application/x-www-form-urlencoded")
       if ['POST', 'PUT'].include?(method) && form_encoded
         CGI.parse(request.normalize_body.to_s)
       else

--- a/lib/oauth/request_proxy/net_http.rb
+++ b/lib/oauth/request_proxy/net_http.rb
@@ -52,7 +52,7 @@ module OAuth::RequestProxy::Net
       end
 
       def form_url_encoded?
-        request['Content-Type'] != nil && request['Content-Type'].downcase == 'application/x-www-form-urlencoded'
+        request['Content-Type'] != nil && request['Content-Type'].to_s.downcase.start_with?('application/x-www-form-urlencoded')
       end
 
       def query_params

--- a/lib/oauth/request_proxy/rack_request.rb
+++ b/lib/oauth/request_proxy/rack_request.rb
@@ -34,9 +34,9 @@ module OAuth::RequestProxy
     end
 
     def request_params
-      if request.content_type and request.content_type.downcase == 'application/x-www-form-urlencoded'
+      if request.content_type and request.content_type.to_s.downcase.start_with?("application/x-www-form-urlencoded")
         request.POST
-      else 
+      else
         {}
       end
     end

--- a/lib/oauth/request_proxy/typhoeus_request.rb
+++ b/lib/oauth/request_proxy/typhoeus_request.rb
@@ -43,7 +43,7 @@ module OAuth::RequestProxy::Typhoeus
 
     def post_parameters
       # Post params are only used if posting form data
-      if(method == 'POST' && request.headers['Content-Type'] && request.headers['Content-Type'].downcase == 'application/x-www-form-urlencoded')
+      if(method == 'POST' && request.headers['Content-Type'] && request.headers['Content-Type'].to_s.downcase.start_with?("application/x-www-form-urlencoded"))
         request.body || {}
       else
         {}


### PR DESCRIPTION
Sometimes it's better to use Net::HTTPGenericRequest instead of Net::HTTP::Get, especially when you need streaming, etc. Net::HTTPGenericRequest is a superclass of Net::HTTPRequest, so the patch doesn't break anything - just allows to sign Net::HTTPGenericRequest instances.
