### PR TITLE
Allowed for normalizing nested hash structures

### DIFF
--- a/lib/oauth/helper.rb
+++ b/lib/oauth/helper.rb
@@ -33,16 +33,21 @@ module OAuth
     # name-value pair is separated by an "&" character.
     #
     # See Also: {OAuth core spec version 1.0, section 9.1.1}[http://oauth.net/core/1.0#rfc.section.9.1.1]
-    def normalize(params)
+    def normalize(params, prefix = nil)
       params.sort.map do |k, values|
+        key = escape(k)
+        key = "#{prefix}%5B#{key}%5D" if prefix
 
         if values.is_a?(Array)
           # multiple values were provided for a single key
           values.sort.collect do |v|
-            [escape(k),escape(v)] * "="
+            [key,escape(v)] * "="
           end
+        elsif values.is_a?(Hash)
+		  # nested values were provided for a single key
+          normalize(values,key)
         else
-          [escape(k),escape(values)] * "="
+          [key,escape(values)] * "="
         end
       end * "&"
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require 'mocha'
 require 'stringio'
 require 'webmock/test_unit'
 
-class Test::Unit::TestCase
+class TestHelper < Test::Unit::TestCase
   def assert_matching_headers(expected, actual)
     # transform into sorted arrays
     auth_intro, auth_params = actual.split(' ', 2)
@@ -22,5 +22,13 @@ class Test::Unit::TestCase
     stub_request(:post, "http://term.ie/oauth/example/access_token.php").to_return(:body => "oauth_token=accesskey&oauth_token_secret=accesssecret")
     stub_request(:get, %r{http://term\.ie/oauth/example/echo_api\.php\?.+}).to_return(lambda {|request| {:body => request.uri.query}})
     stub_request(:post, "http://term.ie/oauth/example/echo_api.php").to_return(lambda {|request| {:body => request.body}})
+  end
+  
+  def test_normalize
+	# test array
+	assert_equal OAuth::Helper::normalize([["one",1],["two",2]]), "one=1&two=2"
+	
+	# test hash and sorting
+	assert_equal OAuth::Helper::normalize([["car",{"volvo" => 1, "saab" => 2}]]), "car%5Bsaab%5D=2&car%5Bvolvo%5D=1"
   end
 end


### PR DESCRIPTION
Added ability to normalize nested hash structures. Rails uses hash structures for most form data.
