### PR TITLE
set a default but configurable timeout for all requests

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -317,6 +317,10 @@ module OAuth
       else
         http_object.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
+
+      http_object.read_timeout = http_object.open_timeout = @options[:timeout] || 30
+      http_object.open_timeout = @options[:open_timeout] if @options[:open_timeout]
+
       http_object
     end
 


### PR DESCRIPTION
Twitter went down.  We found a test that wasn't stubbed properly :)  This fix is currently deployed on GitHub.com, and I'm still able to authorize the Twitter service hook.
