### PR TITLE
Fix nested hash params in Consumer#request posts

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -352,9 +352,8 @@ module OAuth
       end
 
       if data.is_a?(Hash)
-        form_data = {}
-        data.each {|k,v| form_data[k.to_s] = v if !v.nil?}
-        request.set_form_data(form_data)
+        request.body = OAuth::Helper.normalize(data)
+        request.content_type = 'application/x-www-form-urlencoded'
       elsif data
         if data.respond_to?(:read)
           request.body_stream = data

--- a/test/test_consumer.rb
+++ b/test/test_consumer.rb
@@ -89,6 +89,27 @@ class ConsumerTest < Test::Unit::TestCase
     @consumer.request(:get, '/people', nil, {})
   end
 
+  def test_post_of_nested_params_maintains_nesting
+    @consumer=OAuth::Consumer.new(
+      "key",
+      "secret",
+      {
+          :site=>"http://twitter.com"
+      })
+    request = @consumer.create_signed_request(
+      :post,
+      '/people',
+      nil,
+      {},
+      {
+        :key => {
+          :subkey => 'value'
+        }
+      })
+    assert_equal 'key%5Bsubkey%5D=value', request.body
+    assert_equal request.content_type, 'application/x-www-form-urlencoded'
+  end
+
   def test_override_paths
     @consumer=OAuth::Consumer.new(
       "key",


### PR DESCRIPTION
I ran into a situation recently in which oauth-ruby wasn't actually handling Rails-style nested parameters appropriately. The problem was that Net::HTTP only supports top-level params in its requests when set_form_data is used. Calling #to_params or #to_query on the Hash would cause the signature to fail validations. Using the normalize method from OAuth::Helper and setting the body and content_type directly (which is what set_form_data does) solves the problem.

Thanks!
