### PR TITLE
Select correct parser depending on ruby version.

### DIFF
--- a/lib/oauth/helper.rb
+++ b/lib/oauth/helper.rb
@@ -9,9 +9,17 @@ module OAuth
     #
     # See Also: {OAuth core spec version 1.0, section 5.1}[http://oauth.net/core/1.0#rfc.section.5.1]
     def escape(value)
-      URI::escape(value.to_s, OAuth::RESERVED_CHARACTERS)
+      uri_parser.escape(value.to_s, OAuth::RESERVED_CHARACTERS)
     rescue ArgumentError
-      URI::escape(value.to_s.force_encoding(Encoding::UTF_8), OAuth::RESERVED_CHARACTERS)
+      uri_parser.escape(value.to_s.force_encoding(Encoding::UTF_8), OAuth::RESERVED_CHARACTERS)
+    end
+
+    # Return a URI parser suitable for the version of ruby
+    #
+    # This method returns a suitable parser depending on your ruby version. It will stop warnings
+    # appearing in test suites.
+    def uri_parser
+      @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
     end
 
     # Generate a random key of up to +size+ bytes. The value returned is Base64 encoded with non-word


### PR DESCRIPTION
Removes "warning: URI.escape is obsolete" warnings which pop up continuously
during tests of apps / libraries which use this one.
