### PR TITLE
Handle `nil` token gracefully for `RequestToken#authorize_url`

### DIFF
--- a/lib/oauth/tokens/request_token.rb
+++ b/lib/oauth/tokens/request_token.rb
@@ -5,6 +5,8 @@ module OAuth
 
     # Generate an authorization URL for user authorization
     def authorize_url(params = nil)
+      return nil if self.token.nil?
+
       params = (params || {}).merge(:oauth_token => self.token)
       build_authorize_url(consumer.authorize_url, params)
     end

--- a/test/test_request_token.rb
+++ b/test/test_request_token.rb
@@ -35,6 +35,11 @@ class TestRequestToken < Test::Unit::TestCase
     assert_match(/\?oauth_token=/, auth_url)
   end
 
+  def test_request_token_returns_nil_authorize_url_when_token_is_nil
+    @request_token.token = nil
+    assert_nil @request_token.authorize_url
+  end
+
   #TODO: mock out the Consumer to test the Consumer/AccessToken interaction.
   def test_get_access_token
   end


### PR DESCRIPTION
When `RequestToken#authorize_url` and `token` is `nil`, instead of raising an opaque `NoMethodError: undefined method 'gsub' for nil:NilClass` error, return `nil`.
