### PR TITLE
Update to allow raw (as a string) private key in digest

### DIFF
--- a/lib/oauth/signature/rsa/sha1.rb
+++ b/lib/oauth/signature/rsa/sha1.rb
@@ -36,7 +36,7 @@ module OAuth::Signature::RSA
         if options[:private_key_file]
           IO.read(options[:private_key_file])
         else
-          consumer_secret
+          options[:private_key] || consumer_secret
         end
       )
 


### PR DESCRIPTION
Here is a quick trick I used to make it accept private key as a string, which is especially useful on Heroku.

I'm developing client application which needs communicate to the Xero Partners API which uses a combination of 3-legged authorisation, private key message signing and client-side SSL certificate signing.
